### PR TITLE
Update bower.json to add main.css to list of main files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,10 @@
     "Mohammed Basheer"
   ],
   "description": "Angular-Chips is the angular based component. You can use it to add dynamic chips",
-  "main": "./dist/angular-chips.js",
+  "main": [
+    "./dist/angular-chips.js",
+    "./dist/main.css"
+    ],
   "keywords": [
     "angular",
     "chips",


### PR DESCRIPTION
Support for front-end build tools such as [generator-gulp-angular](https://github.com/swiip/generator-gulp-angular) that include the CSS for a bower module automatically.

The CSS must be present in the `main` section of `bower.json` for example:

```
  "main": [
    "./dist/angular-chips.js",
    "./dist/main.css"
  ],

```

More info about [how CSS and JavaScript of Bower modules are inejcted](https://github.com/Swiip/generator-gulp-angular/blob/master/docs/how-it-works.md#gulpinjectjs) 
